### PR TITLE
完成載入換展關閉展廳資料

### DIFF
--- a/src/main/java/us/dontcareabout/npm/client/ConsoleOut.java
+++ b/src/main/java/us/dontcareabout/npm/client/ConsoleOut.java
@@ -14,6 +14,12 @@ public class ConsoleOut {
 		}
 	}
 
+	public static void viewErrorData() {
+		for (RawData data : ExhibitionTable.getErrorDataMap().keySet()) {
+			Console.log(print(data) + " " + ExhibitionTable.getErrorDataMap().get(data));
+		}
+	}
+
 	public static String print(Exhibition e) {
 		return "Name: " + e.getName() + ", " +
 				"Showroom: " + e.getRooms() + ", " +
@@ -45,5 +51,14 @@ public class ConsoleOut {
 		m += "]";
 
 		return m;
+	}
+
+	public static String print(RawData data) {
+		return data.getIndex() + ", " +
+				data.getName() + ", " +
+				data.getClose() + ", " +
+				dateFormat.format(data.getStart()) + ", " +
+				dateFormat.format(data.getEnd()) + ", " +
+				data.getRooms();
 	}
 }

--- a/src/main/java/us/dontcareabout/npm/client/ConsoleOut.java
+++ b/src/main/java/us/dontcareabout/npm/client/ConsoleOut.java
@@ -34,23 +34,25 @@ public class ConsoleOut {
 	}
 
 	public static String print(Map<String, DateInfo> openInterval) {
-		String m = "{";
+		StringBuilder sb = new StringBuilder();
+		sb.append("{");
 		for (String k : openInterval.keySet()) {
-			m += k + "=";
-			m += print(openInterval.get(k));
+			sb.append(k + "=");
+			sb.append(print(openInterval.get(k)) + ", ");
 		}
-		return m + "}";
+		sb.setLength(sb.length() - 2);
+		sb.append("}");
+		return sb.toString();
 	}
 
 	public static String print(DateInfo dateInfo) {
-		String m = "[";
+		StringBuilder sb = new StringBuilder("[");
 		for (DateInterval d : dateInfo.getOpenIntervals()) {
-			m += print(d) + ", ";
+			sb.append(print(d) + ", ");
 		}
-		m = m.substring(0, m.length() - 2);
-		m += "]";
-
-		return m;
+		sb.setLength(sb.length() - 2);
+		sb.append("]");
+		return sb.toString();
 	}
 
 	public static String print(RawData data) {

--- a/src/main/java/us/dontcareabout/npm/client/ConsoleOut.java
+++ b/src/main/java/us/dontcareabout/npm/client/ConsoleOut.java
@@ -3,6 +3,8 @@ package us.dontcareabout.npm.client;
 import com.google.gwt.i18n.client.DateTimeFormat;
 import us.dontcareabout.gwt.client.Console;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
 
 public class ConsoleOut {
@@ -36,21 +38,32 @@ public class ConsoleOut {
 	public static String print(Map<String, DateInfo> openInterval) {
 		StringBuilder sb = new StringBuilder();
 		sb.append("{");
-		for (String k : openInterval.keySet()) {
+
+		List<String> keys = new ArrayList<>(openInterval.keySet());
+		for (int i = 0; i < keys.size(); i++) {
+			String k = keys.get(i);
 			sb.append(k + "=");
-			sb.append(print(openInterval.get(k)) + ", ");
+			sb.append(print(openInterval.get(k)));
+			if (i < keys.size() - 1) {
+				sb.append(", ");
+			}
 		}
-		sb.setLength(sb.length() - 2);
+
 		sb.append("}");
 		return sb.toString();
 	}
 
 	public static String print(DateInfo dateInfo) {
 		StringBuilder sb = new StringBuilder("[");
-		for (DateInterval d : dateInfo.getOpenIntervals()) {
-			sb.append(print(d) + ", ");
+
+		List<DateInterval> openIntervals = dateInfo.getOpenIntervals();
+		for (int i = 0; i < openIntervals.size(); i++) {
+			sb.append(print(openIntervals.get(i)));
+			if (i < openIntervals.size() - 1) {
+				sb.append(", ");
+			}
 		}
-		sb.setLength(sb.length() - 2);
+
 		sb.append("]");
 		return sb.toString();
 	}

--- a/src/main/java/us/dontcareabout/npm/client/ConsoleOut.java
+++ b/src/main/java/us/dontcareabout/npm/client/ConsoleOut.java
@@ -1,0 +1,49 @@
+package us.dontcareabout.npm.client;
+
+import com.google.gwt.i18n.client.DateTimeFormat;
+import us.dontcareabout.gwt.client.Console;
+
+import java.util.Map;
+
+public class ConsoleOut {
+	private final static DateTimeFormat dateFormat = DateTimeFormat.getFormat("yyyy-MM-dd");
+
+	public static void viewExhibitionTable() {
+		for (Exhibition e : ExhibitionTable.getExhibitionTable()) {
+			Console.log(print(e));
+		}
+	}
+
+	public static String print(Exhibition e) {
+		return "Name: " + e.getName() + ", " +
+				"Showroom: " + e.getRooms() + ", " +
+				"Display date: " + print(e.getDisplayDate()) + ", " +
+				"OpenIntervals: " + print(e.getOpenIntervals());
+	}
+
+	public static String print(DateInterval dateInterval) {
+		String start = dateFormat.format(dateInterval.getStart());
+		String end = dateFormat.format(dateInterval.getEnd());
+		return "(" + start + ", " + end + ")";
+	}
+
+	public static String print(Map<String, DateInfo> openInterval) {
+		String m = "{";
+		for (String k : openInterval.keySet()) {
+			m += k + "=";
+			m += print(openInterval.get(k));
+		}
+		return m + "}";
+	}
+
+	public static String print(DateInfo dateInfo) {
+		String m = "[";
+		for (DateInterval d : dateInfo.getOpenIntervals()) {
+			m += print(d) + ", ";
+		}
+		m = m.substring(0, m.length() - 2);
+		m += "]";
+
+		return m;
+	}
+}

--- a/src/main/java/us/dontcareabout/npm/client/DateInfo.java
+++ b/src/main/java/us/dontcareabout/npm/client/DateInfo.java
@@ -1,6 +1,8 @@
 package us.dontcareabout.npm.client;
 
 import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
 import java.util.Date;
 
 /**
@@ -34,6 +36,23 @@ public class DateInfo {
 		}
 
 		//TODO: 處理找不到可切除的日期區間的情形
+	}
+
+	/**
+	 * @return 整個開放日期的範圍
+	 */
+	public DateInterval getOpenRange() {
+		Collections.sort(openIntervals, new Comparator<DateInterval>() {
+			/**
+			 * 比較兩個 DateInterval.start
+			 */
+			@Override
+			public int compare(DateInterval d1, DateInterval d2) {
+				return d1.getStart().compareTo(d2.getStart());
+			}
+		});
+
+		return new DateInterval(openIntervals.get(0).getStart(), openIntervals.get(openIntervals.size() - 1).getEnd());
 	}
 
 	public DateInfo deepClone() {

--- a/src/main/java/us/dontcareabout/npm/client/DateInfo.java
+++ b/src/main/java/us/dontcareabout/npm/client/DateInfo.java
@@ -28,6 +28,7 @@ public class DateInfo {
 				// 這邊無法移動日期
 				openIntervals.add(new DateInterval(closeInterval.getEnd(), dateInterval.getEnd())); //應為 closeInterval.getEnd() +1 天
 				dateInterval.setEnd(closeInterval.getStart()); // 應為 closeInterval.getStart() -1 天
+				sort();
 				return;
 			}
 		}
@@ -35,10 +36,7 @@ public class DateInfo {
 		throw new CutDateIntervalException(closeInterval, openIntervals);
 	}
 
-	/**
-	 * @return 整個開放日期的範圍
-	 */
-	public DateInterval getOpenRange() {
+	public void sort() {
 		Collections.sort(openIntervals, new Comparator<DateInterval>() {
 			/**
 			 * 比較兩個 DateInterval.start
@@ -48,8 +46,10 @@ public class DateInfo {
 				return d1.getStart().compareTo(d2.getStart());
 			}
 		});
+	}
 
-		return new DateInterval(openIntervals.get(0).getStart(), openIntervals.get(openIntervals.size() - 1).getEnd());
+	public DateInterval getOpenRange() {
+		return openRange;
 	}
 
 	public DateInfo deepClone() {

--- a/src/main/java/us/dontcareabout/npm/client/DateInfo.java
+++ b/src/main/java/us/dontcareabout/npm/client/DateInfo.java
@@ -15,6 +15,16 @@ public class DateInfo {
 	private ArrayList<DateInterval> openIntervals = new ArrayList<>();
 	private DateInterval openRange;
 
+	private final static Comparator<DateInterval> DateIntervalComparator = new Comparator<DateInterval>() {
+		/**
+		 * 比較兩個 DateInterval.start
+		 */
+		@Override
+		public int compare(DateInterval d1, DateInterval d2) {
+			return d1.getStart().compareTo(d2.getStart());
+		}
+	};
+
 	DateInfo(Date date1, Date date2) {
 		openRange = new DateInterval(date1, date2);
 		openIntervals.add(new DateInterval(date1, date2));
@@ -32,24 +42,12 @@ public class DateInfo {
 				Date oldEnd = new DateWrapper(closeInterval.getStart()).addDays(-1).asDate();
 				openIntervals.add(new DateInterval(newStart, dateInterval.getEnd()));
 				dateInterval.setEnd(oldEnd);
-				sort();
+				Collections.sort(openIntervals, DateIntervalComparator);
 				return;
 			}
 		}
 
 		throw new CutDateIntervalException(closeInterval, this);
-	}
-
-	public void sort() {
-		Collections.sort(openIntervals, new Comparator<DateInterval>() {
-			/**
-			 * 比較兩個 DateInterval.start
-			 */
-			@Override
-			public int compare(DateInterval d1, DateInterval d2) {
-				return d1.getStart().compareTo(d2.getStart());
-			}
-		});
 	}
 
 	public DateInterval getOpenRange() {
@@ -59,12 +57,9 @@ public class DateInfo {
 	public DateInfo deepClone() {
 		DateInfo newDateInfo = new DateInfo(openRange.getStart(), openRange.getEnd());
 
-		ArrayList<DateInterval> newIntervals = new ArrayList<>();
 		for (DateInterval dateInterval : openIntervals) {
-			newIntervals.add(new DateInterval(dateInterval.getStart(), dateInterval.getEnd()));
+			newDateInfo.openIntervals.add(new DateInterval(dateInterval.getStart(), dateInterval.getEnd()));
 		}
-
-		newDateInfo.openIntervals = newIntervals;
 		return newDateInfo;
 	}
 

--- a/src/main/java/us/dontcareabout/npm/client/DateInfo.java
+++ b/src/main/java/us/dontcareabout/npm/client/DateInfo.java
@@ -1,5 +1,7 @@
 package us.dontcareabout.npm.client;
 
+import us.dontcareabout.npm.client.Exception.CutDateIntervalException;
+
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
@@ -35,7 +37,7 @@ public class DateInfo {
 			}
 		}
 
-		//TODO: 處理找不到可切除的日期區間的情形
+		throw new CutDateIntervalException(closeInterval, openIntervals);
 	}
 
 	/**

--- a/src/main/java/us/dontcareabout/npm/client/DateInfo.java
+++ b/src/main/java/us/dontcareabout/npm/client/DateInfo.java
@@ -22,8 +22,10 @@ public class DateInfo {
 
 	/**
 	 * 從展廳開放日期區間切除展廳暫時閉閉日期區間
+	 *
+	 * @throws CutDateIntervalException {@param closeInterval} 不在 {@link DateInfo} 範圍內
 	 */
-	public void cutCloseInterval(DateInterval closeInterval) {
+	public void cutCloseInterval(DateInterval closeInterval) throws CutDateIntervalException {
 		for (DateInterval dateInterval : openIntervals) {
 			if (dateInterval.contains(closeInterval)) {
 				CalendarUtil.addDaysToDate(closeInterval.getEnd(), 1);

--- a/src/main/java/us/dontcareabout/npm/client/DateInfo.java
+++ b/src/main/java/us/dontcareabout/npm/client/DateInfo.java
@@ -37,7 +37,7 @@ public class DateInfo {
 			}
 		}
 
-		throw new CutDateIntervalException(closeInterval, openIntervals);
+		throw new CutDateIntervalException(closeInterval, this);
 	}
 
 	public void sort() {

--- a/src/main/java/us/dontcareabout/npm/client/DateInfo.java
+++ b/src/main/java/us/dontcareabout/npm/client/DateInfo.java
@@ -28,10 +28,12 @@ public class DateInfo {
 	public void cutCloseInterval(DateInterval closeInterval) throws CutDateIntervalException {
 		for (DateInterval dateInterval : openIntervals) {
 			if (dateInterval.contains(closeInterval)) {
-				CalendarUtil.addDaysToDate(closeInterval.getEnd(), 1);
-				CalendarUtil.addDaysToDate(closeInterval.getStart(), -1);
-				openIntervals.add(new DateInterval(closeInterval.getEnd(), dateInterval.getEnd()));
-				dateInterval.setEnd(closeInterval.getStart());
+				Date newStart = new Date(closeInterval.getEnd().getTime());
+				Date oldEnd = new Date(closeInterval.getStart().getTime());
+				CalendarUtil.addDaysToDate(newStart, 1);
+				CalendarUtil.addDaysToDate(oldEnd, -1);
+				openIntervals.add(new DateInterval(newStart, dateInterval.getEnd()));
+				dateInterval.setEnd(oldEnd);
 				sort();
 				return;
 			}

--- a/src/main/java/us/dontcareabout/npm/client/DateInfo.java
+++ b/src/main/java/us/dontcareabout/npm/client/DateInfo.java
@@ -1,5 +1,6 @@
 package us.dontcareabout.npm.client;
 
+import com.google.gwt.user.datepicker.client.CalendarUtil;
 import us.dontcareabout.npm.client.Exception.CutDateIntervalException;
 
 import java.util.ArrayList;
@@ -25,9 +26,10 @@ public class DateInfo {
 	public void cutCloseInterval(DateInterval closeInterval) {
 		for (DateInterval dateInterval : openIntervals) {
 			if (dateInterval.contains(closeInterval)) {
-				// 這邊無法移動日期
-				openIntervals.add(new DateInterval(closeInterval.getEnd(), dateInterval.getEnd())); //應為 closeInterval.getEnd() +1 天
-				dateInterval.setEnd(closeInterval.getStart()); // 應為 closeInterval.getStart() -1 天
+				CalendarUtil.addDaysToDate(closeInterval.getEnd(), 1);
+				CalendarUtil.addDaysToDate(closeInterval.getStart(), -1);
+				openIntervals.add(new DateInterval(closeInterval.getEnd(), dateInterval.getEnd()));
+				dateInterval.setEnd(closeInterval.getStart());
 				sort();
 				return;
 			}

--- a/src/main/java/us/dontcareabout/npm/client/DateInfo.java
+++ b/src/main/java/us/dontcareabout/npm/client/DateInfo.java
@@ -1,6 +1,6 @@
 package us.dontcareabout.npm.client;
 
-import com.google.gwt.user.datepicker.client.CalendarUtil;
+import com.sencha.gxt.core.client.util.DateWrapper;
 import us.dontcareabout.npm.client.Exception.CutDateIntervalException;
 
 import java.util.ArrayList;
@@ -28,10 +28,8 @@ public class DateInfo {
 	public void cutCloseInterval(DateInterval closeInterval) throws CutDateIntervalException {
 		for (DateInterval dateInterval : openIntervals) {
 			if (dateInterval.contains(closeInterval)) {
-				Date newStart = new Date(closeInterval.getEnd().getTime());
-				Date oldEnd = new Date(closeInterval.getStart().getTime());
-				CalendarUtil.addDaysToDate(newStart, 1);
-				CalendarUtil.addDaysToDate(oldEnd, -1);
+				Date newStart = new DateWrapper(closeInterval.getEnd()).addDays(1).asDate();
+				Date oldEnd = new DateWrapper(closeInterval.getStart()).addDays(-1).asDate();
 				openIntervals.add(new DateInterval(newStart, dateInterval.getEnd()));
 				dateInterval.setEnd(oldEnd);
 				sort();

--- a/src/main/java/us/dontcareabout/npm/client/DateInfo.java
+++ b/src/main/java/us/dontcareabout/npm/client/DateInfo.java
@@ -36,6 +36,14 @@ public class DateInfo {
 		//TODO: 處理找不到可切除的日期區間的情形
 	}
 
+	public DateInfo deepClone() {
+		DateInfo newDateInfo = new DateInfo();
+		for (DateInterval dateInterval : openIntervals) {
+			newDateInfo.addOpenInterval(dateInterval.getStart(), dateInterval.getEnd());
+		}
+		return newDateInfo;
+	}
+
 	public ArrayList<DateInterval> getOpenIntervals() {
 		return openIntervals;
 	}

--- a/src/main/java/us/dontcareabout/npm/client/DateInfo.java
+++ b/src/main/java/us/dontcareabout/npm/client/DateInfo.java
@@ -23,8 +23,17 @@ public class DateInfo {
 	/**
 	 * 從展廳開放日期區間切除展廳暫時閉閉日期區間
 	 */
-	public void cutCloseInterval(DateInterval di) {
+	public void cutCloseInterval(DateInterval closeInterval) {
+		for (DateInterval dateInterval : openIntervals) {
+			if (dateInterval.contains(closeInterval)) {
+				// 這邊無法移動日期
+				addOpenInterval(closeInterval.getEnd(), dateInterval.getEnd()); //應為 closeInterval.getEnd() +1 天
+				dateInterval.setEnd(closeInterval.getStart()); // 應為 closeInterval.getStart() -1 天
+				return;
+			}
+		}
 
+		//TODO: 處理找不到可切除的日期區間的情形
 	}
 
 	public ArrayList<DateInterval> getOpenIntervals() {

--- a/src/main/java/us/dontcareabout/npm/client/DateInfo.java
+++ b/src/main/java/us/dontcareabout/npm/client/DateInfo.java
@@ -11,16 +11,11 @@ import java.util.Date;
  * 開放日期區間
  */
 public class DateInfo {
-	ArrayList<DateInterval> openIntervals;
+	private ArrayList<DateInterval> openIntervals = new ArrayList<>();
+	private DateInterval openRange;
 
-	DateInfo() {
-		openIntervals = new ArrayList<>();
-	}
-
-	/**
-	 * 加入展廳開放日期區間
-	 */
-	public void addOpenInterval(Date date1, Date date2) {
+	DateInfo(Date date1, Date date2) {
+		openRange = new DateInterval(date1, date2);
 		openIntervals.add(new DateInterval(date1, date2));
 	}
 
@@ -31,7 +26,7 @@ public class DateInfo {
 		for (DateInterval dateInterval : openIntervals) {
 			if (dateInterval.contains(closeInterval)) {
 				// 這邊無法移動日期
-				addOpenInterval(closeInterval.getEnd(), dateInterval.getEnd()); //應為 closeInterval.getEnd() +1 天
+				openIntervals.add(new DateInterval(closeInterval.getEnd(), dateInterval.getEnd())); //應為 closeInterval.getEnd() +1 天
 				dateInterval.setEnd(closeInterval.getStart()); // 應為 closeInterval.getStart() -1 天
 				return;
 			}
@@ -58,10 +53,14 @@ public class DateInfo {
 	}
 
 	public DateInfo deepClone() {
-		DateInfo newDateInfo = new DateInfo();
+		DateInfo newDateInfo = new DateInfo(openRange.getStart(), openRange.getEnd());
+
+		ArrayList<DateInterval> newIntervals = new ArrayList<>();
 		for (DateInterval dateInterval : openIntervals) {
-			newDateInfo.addOpenInterval(dateInterval.getStart(), dateInterval.getEnd());
+			newIntervals.add(new DateInterval(dateInterval.getStart(), dateInterval.getEnd()));
 		}
+
+		newDateInfo.openIntervals = newIntervals;
 		return newDateInfo;
 	}
 

--- a/src/main/java/us/dontcareabout/npm/client/DateInterval.java
+++ b/src/main/java/us/dontcareabout/npm/client/DateInterval.java
@@ -14,6 +14,13 @@ public class DateInterval {
 		this.end = date1.after(date2) ? date1 : date2;
 	}
 
+	/**
+	 * @return 是否包含 {@param innerInterval}
+	 */
+	public boolean contains(DateInterval innerInterval) {
+		return start.before(innerInterval.start) && end.after(innerInterval.end);
+	}
+
 	public Date getStart() {
 		return start;
 	}

--- a/src/main/java/us/dontcareabout/npm/client/Exception/CutDateIntervalException.java
+++ b/src/main/java/us/dontcareabout/npm/client/Exception/CutDateIntervalException.java
@@ -4,7 +4,7 @@ import us.dontcareabout.npm.client.DateInterval;
 
 import java.util.List;
 
-public class CutDateIntervalException extends RuntimeException {
+public class CutDateIntervalException extends Exception {
 	public final DateInterval inner;
 	public final List<DateInterval> outer;
 

--- a/src/main/java/us/dontcareabout/npm/client/Exception/CutDateIntervalException.java
+++ b/src/main/java/us/dontcareabout/npm/client/Exception/CutDateIntervalException.java
@@ -1,0 +1,17 @@
+package us.dontcareabout.npm.client.Exception;
+
+import us.dontcareabout.npm.client.DateInterval;
+
+import java.util.List;
+
+public class CutDateIntervalException extends RuntimeException {
+	public final DateInterval inner;
+	public final List<DateInterval> outer;
+
+	public CutDateIntervalException(DateInterval inner, List<DateInterval> outer) {
+		super(inner + " is not in " + outer);
+		this.inner = inner;
+		this.outer = outer;
+	}
+
+}

--- a/src/main/java/us/dontcareabout/npm/client/Exception/CutDateIntervalException.java
+++ b/src/main/java/us/dontcareabout/npm/client/Exception/CutDateIntervalException.java
@@ -1,15 +1,15 @@
 package us.dontcareabout.npm.client.Exception;
 
+import us.dontcareabout.npm.client.ConsoleOut;
+import us.dontcareabout.npm.client.DateInfo;
 import us.dontcareabout.npm.client.DateInterval;
-
-import java.util.List;
 
 public class CutDateIntervalException extends Exception {
 	public final DateInterval inner;
-	public final List<DateInterval> outer;
+	public final DateInfo outer;
 
-	public CutDateIntervalException(DateInterval inner, List<DateInterval> outer) {
-		super(inner + " is not in " + outer);
+	public CutDateIntervalException(DateInterval inner, DateInfo outer) {
+		super(ConsoleOut.print(inner) + " is not in " + ConsoleOut.print(outer));
 		this.inner = inner;
 		this.outer = outer;
 	}

--- a/src/main/java/us/dontcareabout/npm/client/Exception/ExhibitionNotFoundException.java
+++ b/src/main/java/us/dontcareabout/npm/client/Exception/ExhibitionNotFoundException.java
@@ -1,6 +1,6 @@
 package us.dontcareabout.npm.client.Exception;
 
-public class ExhibitionNotFoundException extends RuntimeException {
+public class ExhibitionNotFoundException extends Exception {
 	public final String exhibitionName;
 
 	public ExhibitionNotFoundException(String exhibitionName) {

--- a/src/main/java/us/dontcareabout/npm/client/Exception/ExhibitionNotFoundException.java
+++ b/src/main/java/us/dontcareabout/npm/client/Exception/ExhibitionNotFoundException.java
@@ -1,0 +1,10 @@
+package us.dontcareabout.npm.client.Exception;
+
+public class ExhibitionNotFoundException extends RuntimeException {
+	public final String exhibitionName;
+
+	public ExhibitionNotFoundException(String exhibitionName) {
+		super(exhibitionName);
+		this.exhibitionName = exhibitionName;
+	}
+}

--- a/src/main/java/us/dontcareabout/npm/client/Exception/RoomCannotSplitException.java
+++ b/src/main/java/us/dontcareabout/npm/client/Exception/RoomCannotSplitException.java
@@ -1,6 +1,6 @@
 package us.dontcareabout.npm.client.Exception;
 
-public class RoomCannotSplitException extends RuntimeException {
+public class RoomCannotSplitException extends Exception {
 	public final String room;
 
 	public RoomCannotSplitException(String room) {

--- a/src/main/java/us/dontcareabout/npm/client/Exception/RoomCannotSplitException.java
+++ b/src/main/java/us/dontcareabout/npm/client/Exception/RoomCannotSplitException.java
@@ -1,0 +1,10 @@
+package us.dontcareabout.npm.client.Exception;
+
+public class RoomCannotSplitException extends RuntimeException {
+	public final String room;
+
+	public RoomCannotSplitException(String room) {
+		super(room);
+		this.room = room;
+	}
+}

--- a/src/main/java/us/dontcareabout/npm/client/Exception/RoomNotFoundException.java
+++ b/src/main/java/us/dontcareabout/npm/client/Exception/RoomNotFoundException.java
@@ -1,0 +1,10 @@
+package us.dontcareabout.npm.client.Exception;
+
+public class RoomNotFoundException extends RuntimeException {
+	public final String room;
+
+	public RoomNotFoundException(String room) {
+		super(room);
+		this.room = room;
+	}
+}

--- a/src/main/java/us/dontcareabout/npm/client/Exception/RoomNotFoundException.java
+++ b/src/main/java/us/dontcareabout/npm/client/Exception/RoomNotFoundException.java
@@ -1,6 +1,6 @@
 package us.dontcareabout.npm.client.Exception;
 
-public class RoomNotFoundException extends RuntimeException {
+public class RoomNotFoundException extends Exception {
 	public final String room;
 
 	public RoomNotFoundException(String room) {

--- a/src/main/java/us/dontcareabout/npm/client/Exhibition.java
+++ b/src/main/java/us/dontcareabout/npm/client/Exhibition.java
@@ -32,12 +32,11 @@ public class Exhibition {
 	}
 
 	/**
-	 * @return 成功加入換展關閉展廳之資訊
 	 * @throws RoomCannotSplitException {@param data} 中的展間為子展間，無法分割。
 	 * @throws RoomNotFoundException    {@param data} 中的展間，不在 {@link Exhibition} 展間內。
 	 * @throws CutDateIntervalException {@param data} 中的換展日期不在 {@link Exhibition} 展覽期間內。
 	 */
-	public boolean addClose(RawData data)
+	public void addClose(RawData data)
 			throws RoomCannotSplitException, RoomNotFoundException, CutDateIntervalException {
 		ArrayList<String> roomToClose = new ArrayList<>();
 
@@ -55,12 +54,7 @@ public class Exhibition {
 				}
 
 				// 展廳已分兩半，全部關閉
-				List<String> subRooms;
-				try {
-					subRooms = Showroom.splitRoom(closeRoom);
-				} catch (RoomCannotSplitException e) {
-					throw new RoomCannotSplitException(e.room);
-				}
+				List<String> subRooms = Showroom.splitRoom(closeRoom);
 				if (getRooms().containsAll(subRooms)) {
 					roomToClose.addAll(subRooms);
 					continue;
@@ -73,13 +67,8 @@ public class Exhibition {
 
 		DateInterval closeInterval = new DateInterval(data.getStart(), data.getEnd());
 		for (String room : roomToClose) {
-			try {
-				openIntervals.get(room).cutCloseInterval(closeInterval);
-			} catch (CutDateIntervalException e) {
-				throw new CutDateIntervalException(e.inner, e.outer);
-			}
+			openIntervals.get(room).cutCloseInterval(closeInterval);
 		}
-		return true;
 	}
 
 	/**
@@ -88,12 +77,7 @@ public class Exhibition {
 	 * @throws RoomCannotSplitException {@param room} 為子展間，無法分割。
 	 */
 	private void splitRoom(String room) throws RoomCannotSplitException {
-		List<String> subRooms;
-		try {
-			subRooms = Showroom.splitRoom(room);
-		} catch (RoomCannotSplitException e) {
-			throw new RoomCannotSplitException(e.room);
-		}
+		List<String> subRooms = Showroom.splitRoom(room);
 		for (String subRoom : subRooms) {
 			openIntervals.put(subRoom, openIntervals.get(room).deepClone());
 		}

--- a/src/main/java/us/dontcareabout/npm/client/Exhibition.java
+++ b/src/main/java/us/dontcareabout/npm/client/Exhibition.java
@@ -73,6 +73,14 @@ public class Exhibition {
 		openIntervals.remove(room);
 	}
 
+	/**
+	 * 展出期間
+	 */
+	public DateInterval getDisplayDate() {
+		DateInfo intervals = openIntervals.values().iterator().next();
+		return intervals.getOpenRange();
+	}
+
 	public Set<String> getRooms() {
 		return openIntervals.keySet();
 	}

--- a/src/main/java/us/dontcareabout/npm/client/Exhibition.java
+++ b/src/main/java/us/dontcareabout/npm/client/Exhibition.java
@@ -1,5 +1,7 @@
 package us.dontcareabout.npm.client;
 
+import us.dontcareabout.npm.client.Exception.RoomNotFoundException;
+
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -28,9 +30,9 @@ public class Exhibition {
 	}
 
 	/**
-	 * 加入換展關閉展廳之資訊
+	 * @return 成功加入換展關閉展廳之資訊
 	 */
-	public void addClose(RawData data) {
+	public boolean addClose(RawData data) {
 		ArrayList<String> roomToClose = new ArrayList<>();
 
 		for (String r : data.getRooms().split(",")) {
@@ -42,7 +44,7 @@ public class Exhibition {
 				String parentRoom = Showroom.getParentName(closeRoom);
 				if (getRooms().contains(parentRoom)) {
 					splitRoom(parentRoom);
-					roomToClose.addAll(Showroom.splitRoom(parentRoom));
+					roomToClose.add(closeRoom);
 					continue;
 				}
 
@@ -51,7 +53,7 @@ public class Exhibition {
 					roomToClose.addAll(Showroom.splitRoom(closeRoom));
 					continue;
 				}
-				// TODO: 完全找不到展廳的情形
+				throw new RoomNotFoundException(closeRoom);
 			} else {
 				roomToClose.add(closeRoom);
 			}
@@ -61,6 +63,7 @@ public class Exhibition {
 		for (String room : roomToClose) {
 			openIntervals.get(room).cutCloseInterval(closeInterval);
 		}
+		return true;
 	}
 
 	/**

--- a/src/main/java/us/dontcareabout/npm/client/Exhibition.java
+++ b/src/main/java/us/dontcareabout/npm/client/Exhibition.java
@@ -1,7 +1,5 @@
 package us.dontcareabout.npm.client;
 
-import us.dontcareabout.gwt.client.Console;
-
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -43,10 +41,7 @@ public class Exhibition {
 				// 展廳未分兩半，只關閉一半
 				String parentRoom = Showroom.getParentName(closeRoom);
 				if (getRooms().contains(parentRoom)) {
-					for (String subRoom : Showroom.splitRoom(parentRoom)) {
-						openIntervals.put(subRoom, openIntervals.get(parentRoom).deepClone());
-					}
-					openIntervals.remove(parentRoom);
+					splitRoom(parentRoom);
 					roomToClose.addAll(Showroom.splitRoom(parentRoom));
 					continue;
 				}
@@ -66,6 +61,16 @@ public class Exhibition {
 		for (String room : roomToClose) {
 			openIntervals.get(room).cutCloseInterval(closeInterval);
 		}
+	}
+
+	/**
+	 * 分割展間並複制展覽日期區間
+	 */
+	private void splitRoom(String room) {
+		for (String subRoom : Showroom.splitRoom(room)) {
+			openIntervals.put(subRoom, openIntervals.get(room).deepClone());
+		}
+		openIntervals.remove(room);
 	}
 
 	public Set<String> getRooms() {

--- a/src/main/java/us/dontcareabout/npm/client/Exhibition.java
+++ b/src/main/java/us/dontcareabout/npm/client/Exhibition.java
@@ -23,8 +23,7 @@ public class Exhibition {
 
 		for (String r : data.getRooms().split(",")) {
 			String room = r.trim().toUpperCase();
-			DateInfo dateInfo = new DateInfo();
-			dateInfo.addOpenInterval(data.getStart(), data.getEnd());
+			DateInfo dateInfo = new DateInfo(data.getStart(), data.getEnd());
 			openIntervals.put(room, dateInfo);
 		}
 	}

--- a/src/main/java/us/dontcareabout/npm/client/ExhibitionTable.java
+++ b/src/main/java/us/dontcareabout/npm/client/ExhibitionTable.java
@@ -85,15 +85,7 @@ public class ExhibitionTable {
 			throws ExhibitionNotFoundException, RoomCannotSplitException, RoomNotFoundException, CutDateIntervalException {
 		for (Exhibition e : exhibitionTable) {
 			if (e.getName().equals(data.getName())) {
-				try {
-					e.addClose(data);
-				} catch (RoomNotFoundException ex) {
-					throw new RoomNotFoundException(ex.room);
-				} catch (RoomCannotSplitException ex) {
-					throw new RoomCannotSplitException(ex.room);
-				} catch (CutDateIntervalException ex) {
-					throw new CutDateIntervalException(ex.inner, ex.outer);
-				}
+				e.addClose(data);
 				return;
 			}
 		}

--- a/src/main/java/us/dontcareabout/npm/client/ExhibitionTable.java
+++ b/src/main/java/us/dontcareabout/npm/client/ExhibitionTable.java
@@ -2,7 +2,6 @@ package us.dontcareabout.npm.client;
 
 import com.google.gwt.event.shared.HandlerRegistration;
 import com.google.gwt.event.shared.SimpleEventBus;
-import us.dontcareabout.gwt.client.Console;
 import us.dontcareabout.gwt.client.google.Sheet;
 import us.dontcareabout.gwt.client.google.SheetHappen;
 import us.dontcareabout.npm.client.Exception.CutDateIntervalException;
@@ -12,11 +11,14 @@ import us.dontcareabout.npm.client.Exception.RoomNotFoundException;
 
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 public class ExhibitionTable {
 	private static final SimpleEventBus eventBus = new SimpleEventBus();
 	private static final ArrayList<Exhibition> exhibitionTable = new ArrayList<>();
+	private static final Map<RawData, Exception> errorDataMap = new HashMap<>();
 
 	public static HandlerRegistration addDataReadyHandler(DataReadyEvent.DataReadyHandler handler) {
 		return eventBus.addHandler(DataReadyEvent.TYPE, handler);
@@ -26,6 +28,9 @@ public class ExhibitionTable {
 		return Collections.unmodifiableList(exhibitionTable);
 	}
 
+	public static Map<RawData, Exception> getErrorDataMap() {
+		return Collections.unmodifiableMap(errorDataMap);
+	}
 
 	public static void loadFromGoogleSheet(String sheetId) {
 		SheetHappen.<RawData>get(sheetId, 1, new SheetHappen.Callback<RawData>() {
@@ -63,7 +68,7 @@ public class ExhibitionTable {
 			try {
 				addCloseData(data);
 			} catch (ExhibitionNotFoundException | RoomCannotSplitException | RoomNotFoundException | CutDateIntervalException ex) {
-				Console.log(ex);
+				errorDataMap.put(data, ex);
 			}
 		}
 	}

--- a/src/main/java/us/dontcareabout/npm/client/ExhibitionTable.java
+++ b/src/main/java/us/dontcareabout/npm/client/ExhibitionTable.java
@@ -4,6 +4,7 @@ import com.google.gwt.event.shared.HandlerRegistration;
 import com.google.gwt.event.shared.SimpleEventBus;
 import us.dontcareabout.gwt.client.google.Sheet;
 import us.dontcareabout.gwt.client.google.SheetHappen;
+import us.dontcareabout.npm.client.Exception.ExhibitionNotFoundException;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -55,12 +56,14 @@ public class ExhibitionTable {
 		for (RawData data : dataList) {
 			if (!data.getClose()) continue;
 
+			boolean found = false;
 			for (Exhibition e : exhibitionTable) {
 				if (e.getName().equals(data.getName())) {
-					e.addClose(data);
+					found = e.addClose(data);
 					break;
 				}
 			}
+			if (!found) throw new ExhibitionNotFoundException(data.getName());
 		}
 	}
 }

--- a/src/main/java/us/dontcareabout/npm/client/ExhibitionTable.java
+++ b/src/main/java/us/dontcareabout/npm/client/ExhibitionTable.java
@@ -28,7 +28,7 @@ public class ExhibitionTable {
 			public void onSuccess(Sheet<RawData> gs) {
 				ArrayList<RawData> dataList = gs.getEntry();
 				loadExhibitionInfo(dataList);
-
+				loadCloseInfo(dataList);
 				eventBus.fireEvent(new DataReadyEvent());
 			}
 
@@ -51,6 +51,16 @@ public class ExhibitionTable {
 	/**
 	 * 從 dataList 讀取換展關閉展廳資訊
 	 */
-	public void loadCloseInfo(ArrayList<RawData> dataList) {
+	private static void loadCloseInfo(ArrayList<RawData> dataList) {
+		for (RawData data : dataList) {
+			if (!data.getClose()) continue;
+
+			for (Exhibition e : exhibitionTable) {
+				if (e.getName().equals(data.getName())) {
+					e.addClose(data);
+					break;
+				}
+			}
+		}
 	}
 }

--- a/src/main/java/us/dontcareabout/npm/client/NPMEP.java
+++ b/src/main/java/us/dontcareabout/npm/client/NPMEP.java
@@ -31,6 +31,7 @@ public class NPMEP extends GFEP {
 		ExhibitionTable.addDataReadyHandler(new DataReadyEvent.DataReadyHandler() {
 			@Override
 			public void onDataReady(DataReadyEvent event) {
+				ConsoleOut.viewExhibitionTable();
 				Window.alert("載入完成");
 			}
 		});

--- a/src/main/java/us/dontcareabout/npm/client/NPMEP.java
+++ b/src/main/java/us/dontcareabout/npm/client/NPMEP.java
@@ -32,6 +32,7 @@ public class NPMEP extends GFEP {
 			@Override
 			public void onDataReady(DataReadyEvent event) {
 				ConsoleOut.viewExhibitionTable();
+				ConsoleOut.viewErrorData();
 				Window.alert("載入完成");
 			}
 		});

--- a/src/main/java/us/dontcareabout/npm/client/Showroom.java
+++ b/src/main/java/us/dontcareabout/npm/client/Showroom.java
@@ -19,10 +19,12 @@ public class Showroom {
 	}
 
 	/**
-	 * 取得子展間的名稱
+	 * @return 子展間的名稱。當傳入的 {@param room} 非子展間時，回傳 null。
 	 */
-	public static void getSubName(String room) {
-		//TODO
+	public static Character getSubName(String room) {
+		if (!isSubRoom(room)) return null;
+
+		return room.charAt(room.length() - 1);
 	}
 
 	/**

--- a/src/main/java/us/dontcareabout/npm/client/Showroom.java
+++ b/src/main/java/us/dontcareabout/npm/client/Showroom.java
@@ -1,5 +1,7 @@
 package us.dontcareabout.npm.client;
 
+import us.dontcareabout.npm.client.Exception.RoomCannotSplitException;
+
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -41,12 +43,12 @@ public class Showroom {
 	}
 
 	/**
-	 * @return 分割後子展間的名稱。當傳入的 {@param room} 為子展間時，回傳空 List。
+	 * @return 分割後子展間的名稱。當傳入的 {@param room} 為子展間時，throw {@link RoomCannotSplitException}。
 	 */
 	public static List<String> splitRoom(String room) {
 		ArrayList<String> subRooms = new ArrayList<>();
 
-		if (isSubRoom(room)) return subRooms;
+		if (isSubRoom(room)) throw new RoomCannotSplitException(room);
 
 		// 目前應該只需要兩個子展間吧
 		subRooms.add(room + firstSubName);

--- a/src/main/java/us/dontcareabout/npm/client/Showroom.java
+++ b/src/main/java/us/dontcareabout/npm/client/Showroom.java
@@ -13,8 +13,9 @@ public class Showroom {
 	/**
 	 * 判斷是否是子展間
 	 */
-	public static void isSubRoom(String room) {
-		//TODO
+	public static boolean isSubRoom(String room) {
+		// 檢查最後一個字元：非數字為子展間。
+		return !Character.isDigit(room.charAt(room.length() - 1));
 	}
 
 	/**

--- a/src/main/java/us/dontcareabout/npm/client/Showroom.java
+++ b/src/main/java/us/dontcareabout/npm/client/Showroom.java
@@ -1,5 +1,9 @@
 package us.dontcareabout.npm.client;
 
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
 /**
  * 處理展廳
  */
@@ -28,16 +32,25 @@ public class Showroom {
 	}
 
 	/**
-	 * 取得母展間名稱
+	 * @return 母展間名稱
 	 */
-	public static void getParentName(String room) {
-		//TODO
+	public static String getParentName(String room) {
+		if (!isSubRoom(room)) return room;
+
+		return room.substring(0, room.length() - 1);
 	}
 
 	/**
-	 * 將母展間切割為兩個子展間
+	 * @return 分割後子展間的名稱。當傳入的 {@param room} 為子展間時，回傳 null。
 	 */
-	public static void splitRoom(String room) {
-		//TODO
+	public static List<String> splitRoom(String room) {
+		if (isSubRoom(room)) return null;
+
+		ArrayList<String> subRooms = new ArrayList<>();
+		// 目前應該只需要兩個子展間吧
+		subRooms.add(room + firstSubName);
+		subRooms.add(room + ((char) ((int) firstSubName + 1)));
+
+		return Collections.unmodifiableList(subRooms);
 	}
 }

--- a/src/main/java/us/dontcareabout/npm/client/Showroom.java
+++ b/src/main/java/us/dontcareabout/npm/client/Showroom.java
@@ -43,9 +43,10 @@ public class Showroom {
 	}
 
 	/**
-	 * @return 分割後子展間的名稱。當傳入的 {@param room} 為子展間時，throw {@link RoomCannotSplitException}。
+	 * @return 分割後子展間的名稱。
+	 * @throws RoomCannotSplitException {@param room} 為子展間，無法分割。
 	 */
-	public static List<String> splitRoom(String room) {
+	public static List<String> splitRoom(String room) throws RoomCannotSplitException {
 		ArrayList<String> subRooms = new ArrayList<>();
 
 		if (isSubRoom(room)) throw new RoomCannotSplitException(room);

--- a/src/main/java/us/dontcareabout/npm/client/Showroom.java
+++ b/src/main/java/us/dontcareabout/npm/client/Showroom.java
@@ -41,12 +41,13 @@ public class Showroom {
 	}
 
 	/**
-	 * @return 分割後子展間的名稱。當傳入的 {@param room} 為子展間時，回傳 null。
+	 * @return 分割後子展間的名稱。當傳入的 {@param room} 為子展間時，回傳空 List。
 	 */
 	public static List<String> splitRoom(String room) {
-		if (isSubRoom(room)) return null;
-
 		ArrayList<String> subRooms = new ArrayList<>();
+
+		if (isSubRoom(room)) return subRooms;
+
 		// 目前應該只需要兩個子展間吧
 		subRooms.add(room + firstSubName);
 		subRooms.add(room + ((char) ((int) firstSubName + 1)));

--- a/src/main/java/us/dontcareabout/npm/client/Showroom.java
+++ b/src/main/java/us/dontcareabout/npm/client/Showroom.java
@@ -1,0 +1,40 @@
+package us.dontcareabout.npm.client;
+
+/**
+ * 處理展廳
+ */
+public class Showroom {
+
+	/**
+	 * 第一個子展間名稱
+	 */
+	private static final char firstSubName = 'A';
+
+	/**
+	 * 判斷是否是子展間
+	 */
+	public static void isSubRoom(String room) {
+		//TODO
+	}
+
+	/**
+	 * 取得子展間的名稱
+	 */
+	public static void getSubName(String room) {
+		//TODO
+	}
+
+	/**
+	 * 取得母展間名稱
+	 */
+	public static void getParentName(String room) {
+		//TODO
+	}
+
+	/**
+	 * 將母展間切割為兩個子展間
+	 */
+	public static void splitRoom(String room) {
+		//TODO
+	}
+}

--- a/src/main/java/us/dontcareabout/npm/client/Showroom.java
+++ b/src/main/java/us/dontcareabout/npm/client/Showroom.java
@@ -3,11 +3,17 @@ package us.dontcareabout.npm.client;
 import us.dontcareabout.npm.client.Exception.RoomCannotSplitException;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 
 /**
- * 處理展廳
+ * 展間名稱規則：
+ *
+ * 母展間的名稱皆為數字結尾，開頭不受限制。
+ * 例如：S201、S301、S401
+ *
+ * 當母展間被分成兩個或兩個以上區域時，則加上英文字母，作為子展間的名稱。
+ * 例如：S201 被分為兩個區域時，字展間名稱為 S201A、S201B
+ *      S301 被分為三個區域時，字展間名稱為 S301A、S301B、S301C
  */
 public class Showroom {
 
@@ -28,7 +34,9 @@ public class Showroom {
 	 * @return 子展間的名稱。當傳入的 {@param room} 非子展間時，回傳 null。
 	 */
 	public static Character getSubName(String room) {
-		if (!isSubRoom(room)) return null;
+		if (!isSubRoom(room)) {
+			return null;
+		}
 
 		return room.charAt(room.length() - 1);
 	}
@@ -37,24 +45,40 @@ public class Showroom {
 	 * @return 母展間名稱
 	 */
 	public static String getParentName(String room) {
-		if (!isSubRoom(room)) return room;
+		if (!isSubRoom(room)) {
+			return room;
+		}
 
 		return room.substring(0, room.length() - 1);
 	}
 
 	/**
+	 * 將母展間分割成多個子展間
+	 *
+	 * @return 分割後子展間的名稱。
+	 * @param room 母展間名稱
+	 * @param amount 分割數量
+	 * @throws RoomCannotSplitException {@param room} 為子展間，無法分割。
+	 */
+	public static List<String> splitRoom(String room, int amount) throws RoomCannotSplitException {
+		ArrayList<String> subRooms = new ArrayList<>();
+
+		if (isSubRoom(room)) {
+			throw new RoomCannotSplitException(room);
+		}
+		for (int i = 0; i < amount; i++) {
+			subRooms.add(room + ((char) (firstSubName + i)));
+		}
+		return subRooms;
+	}
+
+	/**
+	 * 將母展間分割成兩個子展間
+	 *
 	 * @return 分割後子展間的名稱。
 	 * @throws RoomCannotSplitException {@param room} 為子展間，無法分割。
 	 */
 	public static List<String> splitRoom(String room) throws RoomCannotSplitException {
-		ArrayList<String> subRooms = new ArrayList<>();
-
-		if (isSubRoom(room)) throw new RoomCannotSplitException(room);
-
-		// 目前應該只需要兩個子展間吧
-		subRooms.add(room + firstSubName);
-		subRooms.add(room + ((char) ((int) firstSubName + 1)));
-
-		return Collections.unmodifiableList(subRooms);
+		return splitRoom(room, 2);
 	}
 }


### PR DESCRIPTION
目前我是用 `RuntimeException` 的方式去炸有問題的資料。遇到了問題 ...

以現在網站的運行方式，
應該是不能讓一筆資料錯誤，就讓全部的資料都載入不進去。

我試著在幾個地方處理所有的 `Exception`，列出有問題的資料。

```java
try {
	ExhibitionTable.loadFromGoogleSheet(SHEET_ID);
} catch (Exception e) {
	....
}

```

這個方式抓不到....


但是改到 `ExhibitionTable.loadFromGoogleSheet()` 內的 `onSuccess()` 去處理

```java
ArrayList<RawData> dataList = gs.getEntry();
loadExhibitionInfo(dataList);

try {
    loadCloseInfo(dataList);
} catch (Exception1 | Exception2 | Exception3 e) {
    Console.log(e);
}

eventBus.fireEvent(new DataReadyEvent());

```

它是能抓到 `Exception` 讓資料載入完，
但是如果有多個 `Exception` 的話，它只會印出第一個 `Exception` 的樣子。

 **我該怎麼去處理 `Exception` ？** 


